### PR TITLE
Add OWNERS file for discoveryserver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - victortrac      # Victor Trac <victor@cloudkite.io>
+  - idvoretskyi     # Ihor Dvoretskyi <ihor@linux.com>
+  - eduartua        # Eduar Tua <eduartua@gmail.com>


### PR DESCRIPTION
Sub-task of https://github.com/etcd-io/etcd/issues/16367.

This pull request proposes a layout for the OWNERS file we need to add to each non archived subproject under the etcd-io github organisation as part of the creation of sig-etcd.

Refer to OWNERS documentation: https://www.kubernetes.dev/docs/guide/owners

Note: I have based the contents of this file on the `maintainers-discovery` github team: https://github.com/orgs/etcd-io/teams/maintainers-discovery. Please let me know if any alterations are required.